### PR TITLE
Update Godot maintainer and requires_generate_from_grammar

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -752,18 +752,17 @@ list.gdscript = {
     files = { "src/parser.c", "src/scanner.cc" },
   },
   readme_name = "Godot (gdscript)",
-  maintainers = { "@Shatur95" },
+  maintainers = { "@PrestonKnopp" },
 }
 
 list.godot_resource = {
   install_info = {
     url = "https://github.com/PrestonKnopp/tree-sitter-godot-resource",
     files = { "src/parser.c", "src/scanner.c" },
-    requires_generate_from_grammar = true,
   },
   filetype = "gdresource",
   readme_name = "Godot Resources (gdresource)",
-  maintainers = { "@pierpo" },
+  maintainers = { "@PrestonKnopp" },
 }
 
 list.turtle = {


### PR DESCRIPTION
This updates the maintainer in the Godot definitions and removes the tree-sitter CLI requirement.

Please, @PrestonKnopp, reply to this PR to validate:

- Confirm the requires_generate_from_grammar is not needed anymore.
- Updating the maintainer to you.

Thank you.